### PR TITLE
setting CGO_ENABLED=0 for builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ffoysal/golang-alpine-gcc:1.13
+      - image: golang:1.13-stretch
     working_directory: /go/src/github.com/qlik-oss/kustomize
     steps:
       - checkout
@@ -13,7 +13,7 @@ jobs:
             go build -o /tmp/kustomize main.go
   build_release:
     docker:
-      - image: ffoysal/golang-alpine-gcc:1.13
+      - image: golang:1.13-stretch
     working_directory: /go/src/github.com/qlik-oss/kustomize
     steps:
       - checkout

--- a/qlik-build-all.sh
+++ b/qlik-build-all.sh
@@ -19,7 +19,7 @@ for os in linux darwin windows; do
     fi
 
     pushd kustomize
-    GOOS=${os} GOARCH=${arch} go build -ldflags "${ldFlags}" -o ../${binDir}/${os}/${exeName} main.go
+    CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go build -ldflags "${ldFlags}" -o ../${binDir}/${os}/${exeName} main.go
     popd
 
     pushd ${binDir}/${os}


### PR DESCRIPTION
fixes #16 

If the executable was built like so:
```
MacBook-Pro:kustomize_fork dlx$ docker run -v `pwd`:/kustomize_fork:rw -ti golang:1.13-stretch
root@afdb822eec34:/go# cd /kustomize_fork/
root@afdb822eec34:/kustomize_fork# make qlik-build-all
```

Then this works:
```
MacBook-Pro:kustomize_fork dlx$ docker run -v `pwd`:/kustomize_fork:rw -ti alpine:latest
/ # cd /kustomize_fork/bin/linux/
/kustomize_fork/bin/linux # ls -la
total 98880
drwxr-xr-x    3 root     root            96 Jan 28 20:55 .
drwxr-xr-x    8 root     root           256 Jan 28 20:57 ..
-rwxr-xr-x    1 root     root     100594702 Jan 28 20:55 kustomize
/kustomize_fork/bin/linux # ./kustomize version
{Version:qlik-dev GitCommit:dad4931815a16e9900e39eeb8ad3c990604a15e5 BuildDate:2020-01-28T20:53:57Z GoOs:linux GoArch:amd64}
/kustomize_fork/bin/linux # 
```