### PR TITLE
Adding an option to replaceWithGitSemverTag

### DIFF
--- a/api/builtins_qlik/GitImageTag.go
+++ b/api/builtins_qlik/GitImageTag.go
@@ -1,13 +1,8 @@
 package builtins_qlik
 
 import (
-	"fmt"
 	"log"
-	"sort"
 
-	"github.com/Masterminds/semver/v3"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"sigs.k8s.io/kustomize/api/builtins"
 	"sigs.k8s.io/kustomize/api/builtins_qlik/utils"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -32,7 +27,7 @@ func (p *GitImageTagPlugin) Config(h *resmap.PluginHelpers, c []byte) (err error
 }
 
 func (p *GitImageTagPlugin) Transform(m resmap.ResMap) error {
-	if headGitTag, err := getHighestSemverGitTagForHead(p.pwd, p.logger); err != nil {
+	if headGitTag, err := utils.GetHighestSemverGitTagForHead(p.pwd, "v0.0.0"); err != nil {
 		return err
 	} else {
 		for _, image := range p.Images {
@@ -57,58 +52,6 @@ func transformForImage(m *resmap.ResMap, gitImageTagPluginImage *GitImageTagPlug
 		}
 	}
 	return nil
-}
-
-func getHighestSemverGitTagForHead(dir string, logger *log.Logger) (string, error) {
-	type tagVersionT struct {
-		tag     string
-		version *semver.Version
-	}
-
-	allSemverTags := make([]*tagVersionT, 0)
-	headSemverTags := make(map[string]bool)
-	var headRef *plumbing.Reference
-
-	if r, err := git.PlainOpenWithOptions(dir, &git.PlainOpenOptions{DetectDotGit: true}); err != nil {
-		return "", err
-	} else if headRef, err = r.Head(); err != nil {
-		return "", err
-	} else if refIter, err := r.Storer.IterReferences(); err != nil {
-		return "", err
-	} else if err := refIter.ForEach(func(t *plumbing.Reference) error {
-		if t.Name().IsTag() {
-			tag := t.Name().Short()
-			if version, err := semver.NewVersion(tag); err != nil {
-				logger.Printf("could not parse tag: %v as semver version, error: %v\n", tag, err)
-			} else {
-				tagVersion := &tagVersionT{
-					tag:     tag,
-					version: version,
-				}
-				allSemverTags = append(allSemverTags, tagVersion)
-				if t.Hash() == headRef.Hash() {
-					headSemverTags[tag] = true
-				}
-			}
-		}
-		return nil
-	}); err != nil {
-		return "", err
-	}
-
-	latestSemverTag := ""
-	if len(allSemverTags) == 0 {
-		latestSemverTag = fmt.Sprintf("v0.0.0-%s", headRef.Hash().String()[0:7])
-	} else {
-		sort.SliceStable(allSemverTags, func(i, j int) bool {
-			return allSemverTags[j].version.LessThan(allSemverTags[i].version)
-		})
-		latestSemverTag = allSemverTags[0].tag
-		if _, ok := headSemverTags[latestSemverTag]; !ok {
-			latestSemverTag = fmt.Sprintf("%s-%s", latestSemverTag, headRef.Hash().String()[0:7])
-		}
-	}
-	return latestSemverTag, nil
 }
 
 func NewGitImageTagPlugin() resmap.TransformerPlugin {

--- a/api/builtins_qlik/GitImageTag_test.go
+++ b/api/builtins_qlik/GitImageTag_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"sigs.k8s.io/kustomize/api/builtins_qlik/utils"
+
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/internal/k8sdeps/transformer"
@@ -124,7 +126,7 @@ func Test_ImageGitTag_getHighestSemverGitTagForHead(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			tag, err := getHighestSemverGitTagForHead(testCase.dir, log.New(os.Stdout, "", log.LstdFlags|log.LUTC|log.Lmicroseconds))
+			tag, err := utils.GetHighestSemverGitTagForHead(testCase.dir, "v0.0.0")
 			if err != nil {
 				t.Fatalf("unexpected error: %v\n", err)
 			}

--- a/api/builtins_qlik/SearchReplace_test.go
+++ b/api/builtins_qlik/SearchReplace_test.go
@@ -3,10 +3,13 @@ package builtins_qlik
 import (
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/builtins_qlik/utils"
 	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/api/loader"
@@ -17,13 +20,15 @@ import (
 )
 
 func TestSearchReplacePlugin(t *testing.T) {
-
-	testCases := []struct {
+	type searchReplacePluginTestCaseT struct {
 		name                 string
 		pluginConfig         string
 		pluginInputResources string
 		checkAssertions      func(*testing.T, resmap.ResMap)
-	}{
+		loaderRootDir        string
+	}
+
+	testCases := []searchReplacePluginTestCaseT{
 		{
 			name: "relaxed is dangerous",
 			pluginConfig: `
@@ -984,6 +989,77 @@ data:
 				}
 			},
 		},
+		func() searchReplacePluginTestCaseT {
+			tmpDir, err := ioutil.TempDir("", "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v\n", err)
+			}
+
+			semverTag := "v0.0.1"
+			subDir, hash, err := setupGitDirWithSubdir(tmpDir, []string{}, []string{"foo", semverTag, "bar"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v\n", err)
+			}
+
+			return searchReplacePluginTestCaseT{
+				name:          "replaceWithGitSemverTag",
+				loaderRootDir: subDir,
+				pluginConfig: `
+apiVersion: qlik.com/v1
+kind: SearchReplace
+metadata:
+  name: notImportantHere
+target:
+  kind: Foo
+  name: some-foo
+path: fooSpec/fooTemplate/fooContainers/env/value
+search: ^far$
+replaceWithGitSemverTag:
+  default: v0.0.0
+`,
+				pluginInputResources: `
+apiVersion: qlik.com/v1
+kind: Foo
+metadata:
+  name: some-foo
+fooSpec:
+  fooTemplate:
+    fooContainers:
+    - name: have-env
+      env:
+      - name: FOO
+        value: far
+      - name: BOO
+        value: farther than it looks
+`,
+				checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
+					res := resMap.GetByIndex(0)
+
+					envVars, err := res.GetFieldValue("fooSpec.fooTemplate.fooContainers[0].env")
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+
+					fooEnvVar := envVars.([]interface{})[0].(map[string]interface{})
+					if "FOO" != fooEnvVar["name"].(string) {
+						t.Fatalf("unexpected: %v\n", fooEnvVar["name"].(string))
+					}
+					expectedFooValue := fmt.Sprintf("%s-%s", semverTag, hash)
+					if expectedFooValue != fooEnvVar["value"].(string) {
+						t.Fatalf("unexpected: %v\n", fooEnvVar["value"].(string))
+					}
+
+					booEnvVar := envVars.([]interface{})[1].(map[string]interface{})
+					if "BOO" != booEnvVar["name"].(string) {
+						t.Fatalf("unexpected: %v\n", booEnvVar["name"].(string))
+					}
+					if "farther than it looks" != booEnvVar["value"].(string) {
+						t.Fatalf("unexpected: %v\n", booEnvVar["value"].(string))
+					}
+					_ = os.RemoveAll(tmpDir)
+				},
+			}
+		}(),
 	}
 	plugin := SearchReplacePlugin{logger: utils.GetLogger("SearchReplacePlugin")}
 	for _, testCase := range testCases {
@@ -995,7 +1071,17 @@ data:
 				t.Fatalf("Err: %v", err)
 			}
 
-			h := resmap.NewPluginHelpers(loader.NewFileLoaderAtRoot(filesys.MakeFsInMemory()), valtest_test.MakeHappyMapValidator(t), resourceFactory)
+			var ldr ifc.Loader
+			if testCase.loaderRootDir == "" {
+				ldr = loader.NewFileLoaderAtRoot(filesys.MakeFsInMemory())
+			} else {
+				ldr, err = loader.NewLoader(loader.RestrictionRootOnly, testCase.loaderRootDir, filesys.MakeFsOnDisk())
+				if err != nil {
+					t.Fatalf("Err: %v", err)
+				}
+			}
+
+			h := resmap.NewPluginHelpers(ldr, valtest_test.MakeHappyMapValidator(t), resourceFactory)
 			if err := plugin.Config(h, []byte(testCase.pluginConfig)); err != nil {
 				t.Fatalf("Err: %v", err)
 			}

--- a/api/builtins_qlik/utils/gitUtils.go
+++ b/api/builtins_qlik/utils/gitUtils.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func GetHighestSemverGitTagForHead(dir string, defaultSemver string) (string, error) {
+	type tagVersionT struct {
+		tag     string
+		version *semver.Version
+	}
+
+	if defaultSemver == "" {
+		defaultSemver = "v0.0.0"
+	}
+
+	allSemverTags := make([]*tagVersionT, 0)
+	headSemverTags := make(map[string]bool)
+	var headRef *plumbing.Reference
+
+	if r, err := git.PlainOpenWithOptions(dir, &git.PlainOpenOptions{DetectDotGit: true}); err != nil {
+		return "", err
+	} else if headRef, err = r.Head(); err != nil {
+		return "", err
+	} else if refIter, err := r.Storer.IterReferences(); err != nil {
+		return "", err
+	} else if err := refIter.ForEach(func(t *plumbing.Reference) error {
+		if t.Name().IsTag() {
+			tag := t.Name().Short()
+			if version, err := semver.NewVersion(tag); err == nil {
+				tagVersion := &tagVersionT{
+					tag:     tag,
+					version: version,
+				}
+				allSemverTags = append(allSemverTags, tagVersion)
+				if t.Hash() == headRef.Hash() {
+					headSemverTags[tag] = true
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	latestSemverTag := ""
+	if len(allSemverTags) == 0 {
+		latestSemverTag = fmt.Sprintf("%s-%s", defaultSemver, headRef.Hash().String()[0:7])
+	} else {
+		sort.SliceStable(allSemverTags, func(i, j int) bool {
+			return allSemverTags[j].version.LessThan(allSemverTags[i].version)
+		})
+		latestSemverTag = allSemverTags[0].tag
+		if _, ok := headSemverTags[latestSemverTag]; !ok {
+			latestSemverTag = fmt.Sprintf("%s-%s", latestSemverTag, headRef.Hash().String()[0:7])
+		}
+	}
+	return latestSemverTag, nil
+}


### PR DESCRIPTION
If neither `replace` nor `replaceWithObjRef` is specified, but `replaceWithGitSemverTag` is, then the replacement value will be computed as follows:
- If git `head` revision  has semver tags, the highest semver tag will be used.
- If git `head` revision has no semver tags, the highest semver tag from any previous revisions will be used (or `replaceWithGitSemverTag.default` if no semver tags found at all) and short git hash from the `head` will be appended.  