### PR TITLE
ChartHomeFullPath defaults helmChart home and kuz config dir

### DIFF
--- a/api/builtins_qlik/ChartHomeFullPath_test.go
+++ b/api/builtins_qlik/ChartHomeFullPath_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/internal/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
@@ -21,7 +23,7 @@ func TestChartHomeFullPath(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		pluginConfig         func(dir string) string
-		pluginInputResources string
+		pluginInputResources func(dir string) string
 		checkAssertions      func(t *testing.T, res resmap.ResMap, dir string, fileContents []byte)
 	}{
 		{
@@ -31,36 +33,42 @@ func TestChartHomeFullPath(t *testing.T) {
 apiVersion: qlik.com/v1
 kind: ChartHomeFullPath
 metadata:
-  name: qliksense
-chartHome: %v
-`, dir)
+  name: test`)
 				return config
 			},
-			pluginInputResources: `
+			pluginInputResources: func(dir string) string {
+				inputResources := fmt.Sprintf(`
 apiVersion: apps/v1
 kind: HelmChart
 metadata:
-  name: qliksense
-chartName: qliksense
-releaseName: qliksense
-`,
+  name: test
+chartName: test
+releaseName: test
+chartHome: %v`, dir)
+				return inputResources
+			},
 			checkAssertions: func(t *testing.T, resMap resmap.ResMap, dir string, fileContents []byte) {
+
 				res := resMap.GetByIndex(0)
 
-				chartHome, err := res.GetFieldValue("chartHome")
+				dir, err := konfig.DefaultAbsPluginHome(filesys.MakeFsOnDisk())
+				if err != nil {
+					dir = filepath.Join(konfig.HomeDir(), konfig.XdgConfigHomeEnvDefault, konfig.ProgramName, konfig.RelPluginHome)
+				}
+				chartHome := filepath.Join(dir, "qlik", "v1", "charts")
+				chartName, err := res.GetFieldValue("chartName")
 				assert.NoError(t, err)
 
-				assert.NotEqual(t, dir, chartHome)
-
+				directoryName := filepath.Join(chartHome, filepath.Join(chartName.(string)))
 				//open modified directory
-				directory, err := os.Open(chartHome.(string))
+				directory, err := os.Open(directoryName)
 				assert.NoError(t, err)
 				objects, err := directory.Readdir(-1)
 				assert.NoError(t, err)
-
+				defer os.RemoveAll(directoryName)
 				//check the temp file was coppied over correctly
 				for _, obj := range objects {
-					source := chartHome.(string) + "/" + obj.Name()
+					source := filepath.Join(directoryName, obj.Name())
 					readFileContents, err := ioutil.ReadFile(source)
 					assert.NoError(t, err)
 					assert.Equal(t, fileContents, readFileContents)
@@ -71,7 +79,11 @@ releaseName: qliksense
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			// create a temp directory and test file
-			dir, err := ioutil.TempDir("", "test")
+
+			dir, err := ioutil.TempDir("", "charts")
+			assert.NoError(t, err)
+
+			os.Mkdir(filepath.Join(dir, "test"), 0777)
 			assert.NoError(t, err)
 
 			file, err := ioutil.TempFile(dir, "testFile")
@@ -85,7 +97,7 @@ releaseName: qliksense
 			resourceFactory := resmap.NewFactory(resource.NewFactory(
 				kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
 
-			resMap, err := resourceFactory.NewResMapFromBytes([]byte(testCase.pluginInputResources))
+			resMap, err := resourceFactory.NewResMapFromBytes([]byte(testCase.pluginInputResources(dir)))
 			if err != nil {
 				t.Fatalf("Err: %v", err)
 			}

--- a/api/builtins_qlik/HelmChart.go
+++ b/api/builtins_qlik/HelmChart.go
@@ -51,6 +51,7 @@ type HelmChartPlugin struct {
 	ReleaseNamespace               string                 `json:"releaseNamespace,omitempty" yaml:"releaseNamespace,omitempty"`
 	ExtraArgs                      string                 `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
 	SubChart                       string                 `json:"subChart,omitempty" yaml:"subChart,omitempty"`
+	NewChartVersion                string                 `json:"newChartVersion,omitempty" yaml:"newChartVersion,omitempty"`
 	RepoIndexFileStaleAfterSeconds int                    `json:"repoIndexFileStaleAfterSeconds,omitempty" yaml:"repoIndexFileStaleAfterSeconds,omitempty"`
 	LockRetryDelayMinMilliSeconds  int                    `json:"lockRetryDelayMinMilliSeconds,omitempty" yaml:"lockRetryDelayMinMilliSeconds,omitempty"`
 	LockRetryDelayMaxMilliSeconds  int                    `json:"lockRetryDelayMaxMilliSeconds,omitempty" yaml:"lockRetryDelayMaxMilliSeconds,omitempty"`
@@ -457,6 +458,10 @@ func (p *HelmChartPlugin) loadChartWithDependencies(settings *cli.EnvSettings, c
 	c, err := loader.Load(chartPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(p.NewChartVersion) > 0 {
+		c.Metadata.Version = p.NewChartVersion
 	}
 
 	buildingDependencies := false


### PR DESCRIPTION
Uses the chartHome in the incoming helmChart resource, uses the kuz config directory instead of temp

'Signed-off-by: Boris Kuschel <dwb@qlik.com>