### PR TITLE
Change env var for helm repo creds to use case sensitive repo alias

### DIFF
--- a/api/builtins_qlik/GoGetter.go
+++ b/api/builtins_qlik/GoGetter.go
@@ -92,7 +92,7 @@ func (p *GoGetterPlugin) Generate() (resmap.ResMap, error) {
 	oswd, _ := os.Getwd()
 	err = os.Chdir(dir)
 	if err != nil {
-		p.logger.Printf("Error: Unable to set working dir %v\n", dir, err)
+		p.logger.Printf("Error: Unable to set working dir %v: %v\n", dir, err)
 		return nil, err
 	}
 	cmd := exec.Command(currentExe, "build", ".")

--- a/api/builtins_qlik/HelmChart.go
+++ b/api/builtins_qlik/HelmChart.go
@@ -286,8 +286,8 @@ func (p *HelmChartPlugin) helmConfigForChart(settings *cli.EnvSettings, repoName
 	if err := p.helmRepoAdd(settings, &repo.Entry{
 		Name:     repoName,
 		URL:      p.ChartRepo,
-		Username: os.Getenv(strings.ToUpper(fmt.Sprintf("%v_helm_repo_username", repoName))),
-		Password: os.Getenv(strings.ToUpper(fmt.Sprintf("%v_helm_repo_password", repoName)))}); err != nil {
+		Username: os.Getenv(fmt.Sprintf("%v_HELM_REPO_USERNAME", repoName)),
+		Password: os.Getenv(fmt.Sprintf("%v_HELM_REPO_PASSWORD", repoName))}); err != nil {
 		p.logger.Printf("error adding repo: %v, err: %v\n", p.ChartRepo, err)
 		return "", err
 	}
@@ -636,8 +636,8 @@ func getRepoEntryForAliasedDependency(aliasMarker string, dep *chart.Dependency,
 		return &repo.Entry{
 			Name:     repoEntryName,
 			URL:      repoEntryUrl,
-			Username: os.Getenv(strings.ToUpper(fmt.Sprintf("%v_helm_repo_username", repoEntryName))),
-			Password: os.Getenv(strings.ToUpper(fmt.Sprintf("%v_helm_repo_password", repoEntryName))),
+			Username: os.Getenv(fmt.Sprintf("%v_HELM_REPO_USERNAME", repoEntryName)),
+			Password: os.Getenv(fmt.Sprintf("%v_HELM_REPO_PASSWORD", repoEntryName)),
 		}, nil
 	}
 }


### PR DESCRIPTION
for an alias called `qlik`:
`qlik_HELM_REPO_USERNAME`
`qlik_HELM_REPO_PASSWORD`

for an alias called `Qlik`:
`Qlik_HELM_REPO_USERNAME`
`Qlik_HELM_REPO_PASSWORD`

This is the follow the helm repo alias case convention which is case sensitive.