### PR TITLE
Search Replace/Super* Integer support

### DIFF
--- a/api/builtins_qlik/SearchReplace.go
+++ b/api/builtins_qlik/SearchReplace.go
@@ -30,7 +30,7 @@ type SearchReplacePlugin struct {
 	Target                    *types.Selector             `json:"target,omitempty" yaml:"target,omitempty"`
 	Path                      string                      `json:"path,omitempty" yaml:"path,omitempty"`
 	Search                    string                      `json:"search,omitempty" yaml:"search,omitempty"`
-	Replace                   string                      `json:"replace,omitempty" yaml:"replace,omitempty"`
+	Replace                   interface{}                 `json:"replace,omitempty" yaml:"replace,omitempty"`
 	ReplaceWithEnvVar         string                      `json:"replaceWithEnvVar,omitempty" yaml:"replaceWithEnvVar,omitempty"`
 	ReplaceWithObjRef         *types.Var                  `json:"replaceWithObjRef,omitempty" yaml:"replaceWithObjRef,omitempty"`
 	ReplaceWithGitDescribeTag *ReplaceWithGitDescribeTagT `json:"replaceWithGitDescribeTag,omitempty" yaml:"replaceWithGitDescribeTag,omitempty"`
@@ -38,7 +38,7 @@ type SearchReplacePlugin struct {
 	fieldSpec                 types.FieldSpec
 	re                        *regexp.Regexp
 	pwd                       string
-	replaceIsInt              bool
+	replaceStr                string
 }
 
 func (p *SearchReplacePlugin) Config(h *resmap.PluginHelpers, c []byte) (err error) {
@@ -46,6 +46,7 @@ func (p *SearchReplacePlugin) Config(h *resmap.PluginHelpers, c []byte) (err err
 	p.Path = ""
 	p.Search = ""
 	p.Replace = ""
+	p.replaceStr = ""
 	p.ReplaceWithEnvVar = ""
 	p.ReplaceWithObjRef = nil
 	p.ReplaceWithGitDescribeTag = nil
@@ -77,23 +78,36 @@ func (p *SearchReplacePlugin) Transform(m resmap.ResMap) error {
 		p.logger.Printf("error selecting resources based on the target selector, error: %v\n", err)
 		return err
 	}
-
-	if p.Replace == "" {
+	if p.Replace != "" {
+		switch newValue := p.Replace.(type) {
+		case int64:
+			p.replaceStr = strconv.FormatInt(newValue, 10)
+		case bool:
+			p.replaceStr = strconv.FormatBool(newValue)
+		case float64:
+			p.replaceStr = strconv.FormatFloat(newValue, 'f', -1, 64)
+		case string:
+			p.replaceStr = newValue
+		default:
+			return errors.New("Replacement input value of unknown type")
+		}
+	}
+	if p.replaceStr == "" {
 		if p.ReplaceWithObjRef != nil {
 			var replaceEmpty bool
 			for _, res := range m.Resources() {
 				if p.matchesObjRef(res) {
-					var replacementValue string
-					if replacementValue, p.replaceIsInt, err = getReplacementValue(res, p.ReplaceWithObjRef.FieldRef.FieldPath); err != nil {
+					if replacementValue, replace, err := getReplacementValue(res, p.ReplaceWithObjRef.FieldRef.FieldPath); err != nil {
 						p.logger.Printf("error getting replacement value: %v\n", err)
 					} else {
-						p.Replace = replacementValue
+						p.replaceStr = replacementValue
+						p.Replace = replace
 						replaceEmpty = true
 						break
 					}
 				}
 			}
-			if p.Replace == "" && !replaceEmpty {
+			if p.replaceStr == "" && !replaceEmpty {
 				p.logger.Printf("Object Reference could not be found")
 				return nil
 			}
@@ -101,10 +115,12 @@ func (p *SearchReplacePlugin) Transform(m resmap.ResMap) error {
 			if gitDescribeTag, err := utils.GetGitDescribeForHead(p.pwd, p.ReplaceWithGitDescribeTag.Default); err != nil {
 				return err
 			} else {
-				p.Replace = strings.TrimPrefix(gitDescribeTag, "v")
+				p.replaceStr = strings.TrimPrefix(gitDescribeTag, "v")
+				p.Replace = p.replaceStr
 			}
 		} else if len(p.ReplaceWithEnvVar) > 0 {
-			p.Replace = os.Getenv(p.ReplaceWithEnvVar)
+			p.replaceStr = os.Getenv(p.ReplaceWithEnvVar)
+			p.Replace = p.replaceStr
 		}
 	}
 	for _, r := range resources {
@@ -138,28 +154,30 @@ func (p *SearchReplacePlugin) Transform(m resmap.ResMap) error {
 	return nil
 }
 
-func getReplacementValue(res *resource.Resource, fieldPath string) (string, bool, error) {
-	var strVal string
-	var ok bool
-	var isInt bool
-
+func getReplacementValue(res *resource.Resource, fieldPath string) (string, interface{}, error) {
 	if val, err := res.GetFieldValue(fieldPath); err != nil {
-		return "", false, err
-	} else if strVal, ok = val.(string); !ok {
-		if intVal, ok := val.(int64); ok {
-			strVal = strconv.FormatInt(intVal, 10)
-			isInt = true
-		} else {
-			return "", false, errors.New("FieldRef for the ReplaceWithObjRef must point to a value of string or int type")
-		}
-	} else if isSecretDataReplacement(res, fieldPath) {
-		if decodedStrVal, err := base64.StdEncoding.DecodeString(strVal); err != nil {
-			return "", false, err
-		} else {
-			return string(decodedStrVal), false, nil
+		return "", nil, err
+	} else {
+		switch newValue := val.(type) {
+		case int64:
+			return strconv.FormatInt(newValue, 10), val, nil
+		case bool:
+			return strconv.FormatBool(newValue), val, nil
+		case float64:
+			return strconv.FormatFloat(newValue, 'f', -1, 64), val, nil
+		case string:
+			if isSecretDataReplacement(res, fieldPath) {
+				if decodedStrVal, err := base64.StdEncoding.DecodeString(newValue); err != nil {
+					return "", nil, err
+				} else {
+					return string(decodedStrVal), val, nil
+				}
+			}
+			return newValue, val, nil
+		default:
+			return "", false, errors.New("FieldRef for the ReplaceWithObjRef must point to a valid type")
 		}
 	}
-	return strVal, isInt, nil
 }
 
 func isSecretDataReplacement(res *resource.Resource, fieldPath string) bool {
@@ -197,19 +215,37 @@ func (p *SearchReplacePlugin) searchAndReplaceRNode(node *kyaml.RNode, base64Enc
 	if err != nil {
 		return err
 	}
-
-	if _, ok := changed.(string); ok {
-		if p.replaceIsInt {
-			node.YNode().Tag = kyaml.NodeTagInt
-			node.YNode().Style = 0
-		}
-		node.YNode().Value = changed.(string)
-	} else {
-		tempMap := map[string]interface{}{"tmp": changed}
-		if tempMapRNode, err := utils.NewKyamlRNode(tempMap); err != nil {
-			return err
+	if changed != nil {
+		if strChanged, ok := changed.(string); ok {
+			if strChanged == p.replaceStr {
+				switch p.Replace.(type) {
+				case int64:
+					node.YNode().Value = strChanged
+					node.YNode().Tag = kyaml.NodeTagInt
+					node.YNode().Style = 0
+				case bool:
+					node.YNode().Value = strChanged
+					node.YNode().Tag = kyaml.NodeTagBool
+					node.YNode().Style = 0
+				case float64:
+					node.YNode().Value = strChanged
+					node.YNode().Tag = kyaml.NodeTagFloat
+					node.YNode().Style = 0
+				default:
+					node.YNode().Value = strChanged
+					node.YNode().Tag = kyaml.NodeTagString
+				}
+			} else {
+				node.YNode().Value = strChanged
+				node.YNode().Tag = kyaml.NodeTagString
+			}
 		} else {
-			node.SetYNode(tempMapRNode.Field("tmp").Value.YNode())
+			tempMap := map[string]interface{}{"tmp": changed}
+			if tempMapRNode, err := utils.NewKyamlRNode(tempMap); err != nil {
+				return err
+			} else {
+				node.SetYNode(tempMapRNode.Field("tmp").Value.YNode())
+			}
 		}
 	}
 	return nil
@@ -221,11 +257,17 @@ func (p *SearchReplacePlugin) searchAndReplace(in interface{}, base64Encoded boo
 			if decodedValue, err := base64.StdEncoding.DecodeString(target); err != nil {
 				return nil, err
 			} else {
-				replacedDecodedValue := p.re.ReplaceAllString(string(decodedValue), p.Replace)
+				replacedDecodedValue := p.re.ReplaceAllString(string(decodedValue), p.replaceStr)
 				return base64.StdEncoding.EncodeToString([]byte(replacedDecodedValue)), nil
 			}
 		} else {
-			return p.re.ReplaceAllString(target, p.Replace), nil
+			retVal := p.re.ReplaceAllString(target, p.replaceStr)
+			// didn't replace anything to retain type
+			if retVal != target {
+				return retVal, nil
+			} else {
+				return nil, nil
+			}
 		}
 	} else if target, ok := in.(map[string]interface{}); ok {
 		return p.marshallToJsonAndReplace(target)
@@ -240,7 +282,7 @@ func (p *SearchReplacePlugin) marshallToJsonAndReplace(in interface{}) (interfac
 		p.logger.Printf("error marshalling interface to JSON, error: %v\n", err)
 		return nil, err
 	} else {
-		replaced := p.re.ReplaceAllString(string(marshalledTarget), p.Replace)
+		replaced := p.re.ReplaceAllString(string(marshalledTarget), p.replaceStr)
 		if err := json.Unmarshal([]byte(replaced), &in); err != nil {
 			p.logger.Printf("error unmarshalling JSON string after replacements back to interface, error: %v\n", err)
 			return nil, err

--- a/api/builtins_qlik/SearchReplace_test.go
+++ b/api/builtins_qlik/SearchReplace_test.go
@@ -1,7 +1,6 @@
 package builtins_qlik
 
 import (
-	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
 	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
@@ -433,7 +431,7 @@ metadata:
 			},
 		},
 		{
-			name: "object reference, no match bo replace",
+			name: "object reference, integer replace",
 			pluginConfig: `
 apiVersion: qlik.com/v1
 kind: SearchReplace
@@ -464,154 +462,13 @@ fooSpec:
      env:
      - name: FOO
        value: far
-     - name: BOO
-       value: farther than it looks
----
-apiVersion: qlik.com/v1
-kind: Bar
-metadata:
- name: some-chocolate-bar
- labels:
-   myproperty: not far enough
-fooSpec:
- test: test
----
-apiVersion: qlik.com/v1
-kind: Bar
-metadata:
- name: some-bar
- labels:
-   myproperty: not far
-fooSpec:
- test: test
----
-apiVersion: qlik.com/v1
-kind: Foo
-metadata:
- name: some-Foo
- labels:
-   myproperty: not good
-`,
-			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
-				res := resMap.GetByIndex(0)
-
-				envVars, err := res.GetFieldValue("fooSpec.fooTemplate.fooContainers[0].env")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				fooEnvVar := envVars.([]interface{})[0].(map[string]interface{})
-				if "FOO" != fooEnvVar["name"].(string) {
-					t.Fatalf("unexpected: %v\n", fooEnvVar["name"].(string))
-				}
-				if "far" != fooEnvVar["value"].(string) {
-					t.Fatalf("unexpected: %v\n", fooEnvVar["value"].(string))
-				}
-
-				booEnvVar := envVars.([]interface{})[1].(map[string]interface{})
-				if "BOO" != booEnvVar["name"].(string) {
-					t.Fatalf("unexpected: %v\n", booEnvVar["name"].(string))
-				}
-				if "farther than it looks" != booEnvVar["value"].(string) {
-					t.Fatalf("unexpected: %v\n", booEnvVar["value"].(string))
-				}
-			},
-		},
-		{
-			name: "can replace with a blank",
-			pluginConfig: `
-apiVersion: qlik.com/v1
-kind: SearchReplace
-metadata:
- name: notImportantHere
-target:
- kind: Foo
- name: some-foo
-path: fooSpec/fooTemplate/fooContainers/env/value
-search: ^far$
-replace: ""
-`,
-			pluginInputResources: `
-apiVersion: qlik.com/v1
-kind: Foo
-metadata:
- name: some-foo
-fooSpec:
- fooTemplate:
-   fooContainers:
-   - name: have-env
-     env:
-     - name: FOO
-       value: far
-     - name: BOO
-       value: farther than it looks
-`,
-			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
-				res := resMap.GetByIndex(0)
-
-				envVars, err := res.GetFieldValue("fooSpec.fooTemplate.fooContainers[0].env")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				fooEnvVar := envVars.([]interface{})[0].(map[string]interface{})
-				if "FOO" != fooEnvVar["name"].(string) {
-					t.Fatalf("unexpected: %v\n", fooEnvVar["name"].(string))
-				}
-				if "" != fooEnvVar["value"].(string) {
-					t.Fatalf("unexpected: %v\n", fooEnvVar["value"].(string))
-				}
-
-				booEnvVar := envVars.([]interface{})[1].(map[string]interface{})
-				if "BOO" != booEnvVar["name"].(string) {
-					t.Fatalf("unexpected: %v\n", booEnvVar["name"].(string))
-				}
-				if "farther than it looks" != booEnvVar["value"].(string) {
-					t.Fatalf("unexpected: %v\n", booEnvVar["value"].(string))
-				}
-			},
-		},
-		{
-			name: "can replace with a blank from object ref",
-			pluginConfig: `
-apiVersion: qlik.com/v1
-kind: SearchReplace
-metadata:
- name: notImportantHere
-target:
- kind: Foo
- name: some-foo
-path: fooSpec/fooTemplate/fooContainers/env/value
-search: ^far$
-replaceWithObjRef:
- objref:
-   apiVersion: qlik.com/
-   kind: Bar
-   name: Foo
- fieldref:
-   fieldpath: metadata.labels.myproperty
-`,
-			pluginInputResources: `
-apiVersion: qlik.com/v1
-kind: Foo
-metadata:
- name: some-foo
-fooSpec:
- fooTemplate:
-   fooContainers:
-   - name: have-env
-     env:
-     - name: FOO
-       value: far
-     - name: BOO
-       value: farther than it looks
 ---
 apiVersion: qlik.com/v1
 kind: Bar
 metadata:
  name: Foo
  labels:
-   myproperty: ""
+   myproperty: 1234
 fooSpec:
  test: test
 `,
@@ -627,416 +484,67 @@ fooSpec:
 				if "FOO" != fooEnvVar["name"].(string) {
 					t.Fatalf("unexpected: %v\n", fooEnvVar["name"].(string))
 				}
-				if "" != fooEnvVar["value"].(string) {
+				if 1234 != fooEnvVar["value"].(int64) {
+					t.Fatalf("unexpected: %d\n", fooEnvVar["value"].(int64))
+				}
+			},
+		},
+		{
+			name: "object reference, integer as string replace",
+			pluginConfig: `
+apiVersion: qlik.com/v1
+kind: SearchReplace
+metadata:
+ name: notImportantHere
+target:
+ kind: Foo
+ name: some-foo
+path: fooSpec/fooTemplate/fooContainers/env/value
+search: ^far$
+replaceWithObjRef:
+ objref:
+   apiVersion: qlik.com/
+   kind: Bar
+   name: Foo
+ fieldref:
+   fieldpath: metadata.labels.myproperty
+`,
+			pluginInputResources: `
+apiVersion: qlik.com/v1
+kind: Foo
+metadata:
+ name: some-foo
+fooSpec:
+ fooTemplate:
+   fooContainers:
+   - name: have-env
+     env:
+     - name: FOO
+       value: far
+---
+apiVersion: qlik.com/v1
+kind: Bar
+metadata:
+ name: Foo
+ labels:
+   myproperty: "1234"
+fooSpec:
+ test: test
+`,
+			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
+				res := resMap.GetByIndex(0)
+
+				envVars, err := res.GetFieldValue("fooSpec.fooTemplate.fooContainers[0].env")
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				fooEnvVar := envVars.([]interface{})[0].(map[string]interface{})
+				if "FOO" != fooEnvVar["name"].(string) {
+					t.Fatalf("unexpected: %v\n", fooEnvVar["name"].(string))
+				}
+				if "1234" != fooEnvVar["value"].(string) {
 					t.Fatalf("unexpected: %v\n", fooEnvVar["value"].(string))
-				}
-
-				booEnvVar := envVars.([]interface{})[1].(map[string]interface{})
-				if "BOO" != booEnvVar["name"].(string) {
-					t.Fatalf("unexpected: %v\n", booEnvVar["name"].(string))
-				}
-				if "farther than it looks" != booEnvVar["value"].(string) {
-					t.Fatalf("unexpected: %v\n", booEnvVar["value"].(string))
-				}
-			},
-		},
-		{
-			name: "replace label keys",
-			pluginConfig: `
-apiVersion: qlik.com/v1
-kind: SearchReplace
-metadata:
-  name: notImportantHere
-target:
-  kind: Deployment
-path: spec/template/metadata/labels
-search: \b[^"]*-messaging-nats-client\b
-replace: foo-messaging-nats-client
-`,
-			pluginInputResources: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: deployment-1
-spec:
-  template:
-    metadata:
-      labels:
-        app: some-app
-        something-messaging-nats-client: "true"
-        release: some-release
-    spec:
-      containers:
-      - name: name-1
-        image: image-1:latest
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: deployment-2
-spec:
-  template:
-    metadata:
-      labels:
-        app: some-app
-        something-messaging-nats-client: "true"
-        release: some-release
-    spec:
-      containers:
-      - name: name-2
-        image: image-2:latest
-`,
-			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
-				for _, res := range resMap.Resources() {
-					labels, err := res.GetFieldValue("spec.template.metadata.labels")
-					if err != nil {
-						t.Fatalf("unexpected error: %v", err)
-					}
-
-					appLabel := labels.(map[string]interface{})["app"].(string)
-					if "some-app" != appLabel {
-						t.Fatalf("unexpected: %v\n", appLabel)
-					}
-
-					natsClientLabe := labels.(map[string]interface{})["foo-messaging-nats-client"].(string)
-					if "true" != natsClientLabe {
-						t.Fatalf("unexpected: %v\n", natsClientLabe)
-					}
-
-					releaseLabel := labels.(map[string]interface{})["release"].(string)
-					if "some-release" != releaseLabel {
-						t.Fatalf("unexpected: %v\n", releaseLabel)
-					}
-				}
-			},
-		},
-		{
-			name: "replace label key for a custom type and a dollar-variable",
-			pluginConfig: `
-apiVersion: qlik.com/v1
-kind: SearchReplace
-metadata:
-  name: notImportantHere
-target:
-  kind: Engine
-path: spec/metadata/labels
-search: \$\(PREFIX\)-messaging-nats-client
-replace: foo-messaging-nats-client
-`,
-			pluginInputResources: `
-apiVersion: qixmanager.qlik.com/v1
-kind: Engine
-metadata:
-  name: whatever-engine
-spec:
-  metadata:
-    labels:
-      $(PREFIX)-messaging-nats-client: "true"
-`,
-			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
-				for _, res := range resMap.Resources() {
-					labels, err := res.GetFieldValue("spec.metadata.labels")
-					if err != nil {
-						t.Fatalf("unexpected error: %v", err)
-					}
-
-					natsClientLabe := labels.(map[string]interface{})["foo-messaging-nats-client"].(string)
-					if "true" != natsClientLabe {
-						t.Fatalf("unexpected: %v\n", natsClientLabe)
-					}
-				}
-			},
-		},
-		{
-			name: "replace root",
-			pluginConfig: `
-apiVersion: qlik.com/v1
-kind: SearchReplace
-metadata:
-  name: notImportantHere
-target:
-  kind: Deployment
-path: /
-search: \$\(PREFIX\)
-replace: foo
-`,
-			pluginInputResources: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: deployment-1
-spec:
-  template:
-    metadata:
-      labels:
-        $(PREFIX)-messaging-nats-client: "true"
-        $(PREFIX): bar
-    spec:
-      containers:
-      - name: name-1
-        image: $(PREFIX)-image:latest
-`,
-			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
-				expectingFinalDeploymenYaml := `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: deployment-1
-spec:
-  template:
-    metadata:
-      labels:
-        foo: bar
-        foo-messaging-nats-client: "true"
-    spec:
-      containers:
-      - image: foo-image:latest
-        name: name-1
-`
-				if resMapYaml, err := resMap.AsYaml(); err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				} else if string(resMapYaml) != expectingFinalDeploymenYaml {
-					t.Fatalf("unexpected %v, but got: %v", expectingFinalDeploymenYaml, string(resMapYaml))
-				}
-			},
-		},
-		{
-			name: "base64-encoded target and replacement",
-			pluginConfig: `
-apiVersion: qlik.com/v1
-kind: SearchReplace
-metadata:
-  name: notImportantHere
-target:
-  kind: Secret
-  name: keycloak-secret
-path: data/idpConfigs
-search: \$\(QLIKSENSE_DOMAIN\)
-replaceWithObjRef:
-  objref:
-    apiVersion: qlik.com/v1
-    kind: Secret
-    name: gke-configs
-  fieldref:
-    fieldpath: data.qlikSenseDomain
-`,
-			pluginInputResources: `
-apiVersion: v1
-kind: Secret
-metadata:
-  name: keycloak-secret
-type: Opaque
-data:
-  idpConfigs: JChRTElLU0VOU0VfRE9NQUlOKS5iYXIuY29t
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: gke-configs
-type: Opaque
-data:
-  qlikSenseDomain: Zm9v
-`,
-			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
-				res, err := resMap.GetById(resid.NewResId(resid.Gvk{
-					Group:   "",
-					Version: "v1",
-					Kind:    "Secret",
-				}, "keycloak-secret"))
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				base64EncodedIdpConfigs, err := res.GetFieldValue("data.idpConfigs")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				decodedIdpConfigsBytes, err := base64.StdEncoding.DecodeString(base64EncodedIdpConfigs.(string))
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				if string(decodedIdpConfigsBytes) != "foo.bar.com" {
-					t.Fatalf("expected %v to equal %v", string(decodedIdpConfigsBytes), "foo.bar.com")
-				}
-			},
-		},
-		{
-			name: "base64-encoded target and replacement, replace entire (possibly multiline) string",
-			pluginConfig: `
-apiVersion: qlik.com/v1
-kind: SearchReplace
-metadata:
-  name: notImportantHere
-target:
-  kind: Secret
-  name: target-secret
-path: data/tls.crt
-search: (?s).*
-replaceWithObjRef:
-  objref:
-    apiVersion: qlik.com/v1
-    kind: Secret
-    name: source-secret
-  fieldref:
-    fieldpath: data[tls.foo]
-`,
-			pluginInputResources: `
-apiVersion: v1
-kind: Secret
-metadata:
-  name: target-secret
-type: Opaque
-data:
-  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURWRENDQWp5Z0F3SUJBZ0lKQUowdHFNVDVEV3BzTUEwR0NTcUdTSWIzRFFFQkN3VUFNRDh4R0RBV0JnTlYKQkFNTUQyVnNZWE4wYVdNdVpYaGhiWEJzWlRFak1DRUdBMVVFQ2d3YVpXeGhjM1JwWXkxbGJHRnpkR2xqTFd4dgpZMkZzTFdObGNuUXdIaGNOTVRnd05qRXhNVFV4TVRBeldoY05Namd3TkRFNU1UVXhNVEF6V2pBL01SZ3dGZ1lEClZRUUREQTlsYkdGemRHbGpMbVY0WVcxd2JHVXhJekFoQmdOVkJBb01HbVZzWVhOMGFXTXRaV3hoYzNScFl5MXMKYjJOaGJDMWpaWEowTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFwUUxJZ1Z4QwpkRjI3UFhzL3M4VFh2VGRVeTVwZFFneG9jWi9MenUxblJXbW1GRUc1Mlo5MmRjS1dJMDljdVg5ZUlZZzE0c21ZCkczSmtjb28vNUt0WUtpNmh5dVBtNlZrdGRyU1dCam1VdGxkbHg3UVRLNkxFVlhFeUU3VDZ6QW1GV3lMZTVJMEIKbDdRQlk2dnVoK3g1dlpkSWd3SzVldzBFZmNJUU1Ra2tiMzVkb00xYm41TEJEVklxUzNmNXUxNTArMTM1RitsWQpOc2lFcWhZaVExZm1PMmkzSzBLOW5TMEl3Nm5vNWp2MkZaNnR5bU9zY2wvaWYzdWQzUzUxOTZNTjJtaFpCRFVaCmlwbThlRVkxNVJOa3VQSXBETzhMYkEwZlFOcUcyYXFGa3JybFcrbEdTaDRYZjZLNmdtZkFRdW15K2xrR3RqVlUKZU5OdGF6NnlMMWNkU3dJREFRQUJvMU13VVRBTEJnTlZIUThFQkFNQ0JMQXdFd1lEVlIwbEJBd3dDZ1lJS3dZQgpCUVVIQXdFd0xRWURWUjBSQkNZd0pJSVBaV3hoYzNScFl5NWxlR0Z0Y0d4bGdoRXFMbVZzWVhOMGFXTXVaWGhoCmJYQnNaVEFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBVDFnMFhqelNDRDBBTkF5cDFOWURLU3ZZVUdHcGpSaFkKdUJRYnRwcDUrUDNzd2xvdTNvMDVwdDNydlZ3QmxwK2tjalFwTEJpN3AyRFNuNTdFWHM5eHFEQTBHRjlMSHdpUwpzcGZVYlhRazJIa1E3SGpHb01FSEJLVWpOVUJoZjJkWVRuK1BtbHhobllpZitoU2dkeDdIZ1JuMTh0K0hqTC9JClVlUUkxMHYvdExiT1diZkdBZmlGYjQyUHEvVjg1aGJlNW9mU1VObHVsNFZNOGVXNk1SNlB2b1dYYWJYcVB2ajMKSXpVOVk2UVFoN2dqYmNQN2RmWUZCd3FFRnUxOHlpMUdFbzcxK0NtUjFFL2VpK2kzZDdZTHlMTWhUOHZnMVNDUgozeTB1TVZZOHkxVHpIdS9OTEl0NVozYm1rNFJjcUo1MDVsYmtrTHdzSVFYUzJpMUxud25weXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: source-secret
-type: Opaque
-data:
-  tls.foo: Zm9v
-`,
-			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
-				res, err := resMap.GetById(resid.NewResId(resid.Gvk{
-					Group:   "",
-					Version: "v1",
-					Kind:    "Secret",
-				}, "target-secret"))
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				base64EncodedIdpConfigs, err := res.GetFieldValue("data[tls.crt]")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				decodedIdpConfigsBytes, err := base64.StdEncoding.DecodeString(base64EncodedIdpConfigs.(string))
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				if string(decodedIdpConfigsBytes) != "foo" {
-					t.Fatalf("expected %v to equal %v", string(decodedIdpConfigsBytes), "foo.bar.com")
-				}
-			},
-		},
-		{
-			name: "base64-encoded target only",
-			pluginConfig: `
-apiVersion: qlik.com/v1
-kind: SearchReplace
-metadata:
-  name: notImportantHere
-target:
-  kind: Secret
-  name: keycloak-secret
-path: data/idpConfigs
-search: \$\(QLIKSENSE_DOMAIN\)
-replaceWithObjRef:
-  objref:
-    apiVersion: qlik.com/v1
-    kind: ConfigMap
-    mame: gke-configs
-  fieldref:
-    fieldpath: data.qlikSenseDomain
-`,
-			pluginInputResources: `
-apiVersion: v1
-kind: Secret
-metadata:
-  name: keycloak-secret
-type: Opaque
-data:
-  idpConfigs: JChRTElLU0VOU0VfRE9NQUlOKS5iYXIuY29t
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: gke-configs
-data:
-  qlikSenseDomain: foo
-`,
-			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
-				res, err := resMap.GetById(resid.NewResId(resid.Gvk{
-					Group:   "",
-					Version: "v1",
-					Kind:    "Secret",
-				}, "keycloak-secret"))
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				base64EncodedIdpConfigs, err := res.GetFieldValue("data.idpConfigs")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				decodedIdpConfigsBytes, err := base64.StdEncoding.DecodeString(base64EncodedIdpConfigs.(string))
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				if string(decodedIdpConfigsBytes) != "foo.bar.com" {
-					t.Fatalf("expected %v to equal %v", string(decodedIdpConfigsBytes), "foo.bar.com")
-				}
-			},
-		},
-		{
-			name: "base64-encoded replacement only",
-			pluginConfig: `
-apiVersion: qlik.com/v1
-kind: SearchReplace
-metadata:
-  name: notImportantHere
-target:
-  kind: ConfigMap
-  name: keycloak-config
-path: data/idpConfigs
-search: \$\(QLIKSENSE_DOMAIN\)
-replaceWithObjRef:
-  objref:
-    apiVersion: qlik.com/v1
-    kind: Secret
-    mame: gke-secrets
-  fieldref:
-    fieldpath: data.qlikSenseDomain
-`,
-			pluginInputResources: `
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: keycloak-config
-data:
-  idpConfigs: $(QLIKSENSE_DOMAIN).bar.com
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: gke-secrets
-type: Opaque
-data:
-  qlikSenseDomain: Zm9v
-`,
-			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
-				res, err := resMap.GetById(resid.NewResId(resid.Gvk{
-					Group:   "",
-					Version: "v1",
-					Kind:    "ConfigMap",
-				}, "keycloak-config"))
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				idpConfigs, err := res.GetFieldValue("data.idpConfigs")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				if idpConfigs.(string) != "foo.bar.com" {
-					t.Fatalf("expected %v to equal %v", idpConfigs.(string), "foo.bar.com")
 				}
 			},
 		},

--- a/api/builtins_qlik/SearchReplace_test.go
+++ b/api/builtins_qlik/SearchReplace_test.go
@@ -442,6 +442,94 @@ target:
  name: some-foo
 path: fooSpec/fooTemplate/fooContainers/env/value
 search: ^far$
+replace: 1234
+`,
+			pluginInputResources: `
+apiVersion: qlik.com/v1
+kind: Foo
+metadata:
+ name: some-foo
+fooSpec:
+ fooTemplate:
+   fooContainers:
+   - name: have-env
+     env:
+     - name: FOO
+       value: far
+`,
+			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
+				res := resMap.GetByIndex(0)
+
+				envVars, err := res.GetFieldValue("fooSpec.fooTemplate.fooContainers[0].env")
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				fooEnvVar := envVars.([]interface{})[0].(map[string]interface{})
+				if "FOO" != fooEnvVar["name"].(string) {
+					t.Fatalf("unexpected: %v\n", fooEnvVar["name"].(string))
+				}
+				if 1234 != fooEnvVar["value"].(int64) {
+					t.Fatalf("unexpected: %d\n", fooEnvVar["value"].(int64))
+				}
+			},
+		},
+		{
+			name: "object reference, string integer replace",
+			pluginConfig: `
+apiVersion: qlik.com/v1
+kind: SearchReplace
+metadata:
+ name: notImportantHere
+target:
+ kind: Foo
+ name: some-foo
+path: fooSpec/fooTemplate/fooContainers/env/value
+search: ^far$
+replace: '1234'
+`,
+			pluginInputResources: `
+apiVersion: qlik.com/v1
+kind: Foo
+metadata:
+ name: some-foo
+fooSpec:
+ fooTemplate:
+   fooContainers:
+   - name: have-env
+     env:
+     - name: FOO
+       value: far
+`,
+			checkAssertions: func(t *testing.T, resMap resmap.ResMap) {
+				res := resMap.GetByIndex(0)
+
+				envVars, err := res.GetFieldValue("fooSpec.fooTemplate.fooContainers[0].env")
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				fooEnvVar := envVars.([]interface{})[0].(map[string]interface{})
+				if "FOO" != fooEnvVar["name"].(string) {
+					t.Fatalf("unexpected: %v\n", fooEnvVar["name"].(string))
+				}
+				if "1234" != fooEnvVar["value"].(string) {
+					t.Fatalf("unexpected: %v\n", fooEnvVar["value"].(string))
+				}
+			},
+		},
+		{
+			name: "object reference, integer ref replace",
+			pluginConfig: `
+apiVersion: qlik.com/v1
+kind: SearchReplace
+metadata:
+ name: notImportantHere
+target:
+ kind: Foo
+ name: some-foo
+path: fooSpec/fooTemplate/fooContainers/env/value
+search: ^far$
 replaceWithObjRef:
  objref:
    apiVersion: qlik.com/

--- a/api/builtins_qlik/SuperConfigMap.go
+++ b/api/builtins_qlik/SuperConfigMap.go
@@ -12,7 +12,7 @@ import (
 )
 
 type SuperConfigMapPlugin struct {
-	Data   map[string]string `json:"data,omitempty" yaml:"data,omitempty"`
+	Data   map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
 	logger *log.Logger
 	builtins.ConfigMapGeneratorPlugin
 	SuperMapPluginBase
@@ -20,7 +20,7 @@ type SuperConfigMapPlugin struct {
 
 func (p *SuperConfigMapPlugin) Config(h *resmap.PluginHelpers, c []byte) (err error) {
 	p.SuperMapPluginBase = NewBase(h.ResmapFactory(), p)
-	p.Data = make(map[string]string)
+	p.Data = make(map[string](interface{}))
 	err = yaml.Unmarshal(c, p)
 	if err != nil {
 		p.logger.Printf("error unmarshalling yaml, error: %v\n", err)
@@ -66,7 +66,7 @@ func (p *SuperConfigMapPlugin) GetType() string {
 	return "ConfigMap"
 }
 
-func (p *SuperConfigMapPlugin) GetConfigData() map[string]string {
+func (p *SuperConfigMapPlugin) GetConfigData() map[string]interface{} {
 	return p.Data
 }
 

--- a/api/builtins_qlik/SuperSecret.go
+++ b/api/builtins_qlik/SuperSecret.go
@@ -15,7 +15,7 @@ import (
 type SuperSecretPlugin struct {
 	StringData          map[string]string `json:"stringData,omitempty" yaml:"stringData,omitempty"`
 	Data                map[string]string `json:"data,omitempty" yaml:"data,omitempty"`
-	aggregateConfigData map[string]string
+	aggregateConfigData map[string]interface{}
 	logger              *log.Logger
 	builtins.SecretGeneratorPlugin
 	SuperMapPluginBase
@@ -43,8 +43,8 @@ func (p *SuperSecretPlugin) Config(h *resmap.PluginHelpers, c []byte) (err error
 	return p.SecretGeneratorPlugin.Config(h, c)
 }
 
-func (p *SuperSecretPlugin) getAggregateConfigData() (map[string]string, error) {
-	aggregateConfigData := make(map[string]string)
+func (p *SuperSecretPlugin) getAggregateConfigData() (map[string]interface{}, error) {
+	aggregateConfigData := make(map[string]interface{})
 	for k, v := range p.StringData {
 		aggregateConfigData[k] = v
 	}
@@ -91,7 +91,7 @@ func (p *SuperSecretPlugin) GetType() string {
 	return "Secret"
 }
 
-func (p *SuperSecretPlugin) GetConfigData() map[string]string {
+func (p *SuperSecretPlugin) GetConfigData() map[string]interface{} {
 	return p.aggregateConfigData
 }
 


### PR DESCRIPTION
~I think this is a good compromise to having a full blown interface{} Replace var. Floats could also be supported this way.~

I had to do the full blown type implementation because of some unintended consequences of using a separate variable as it pertains to replacement references. 

Functionality as follows:

- When using a path specific to a yaml node (ie. not "/"), the will look the original replacement value/reference type and see if the resulting target replacement has the same value, in which case the origin type is retained.
- For the ("/") case, the regex will need to be crafted to eliminate quotations.
- new `replaceType` attribute can be int64, float64, string or bool and will force the target type to take that type representation in the generated yaml
