### PR TITLE
ci: Use gh cli to check/update/create a release

### DIFF
--- a/.github/workflows/qlik_release.yaml
+++ b/.github/workflows/qlik_release.yaml
@@ -22,13 +22,12 @@ jobs:
       - name: release
         run: |
           set -x
-
-          assets=()
-          for asset in bin/*.tar.gz; do
-            assets+=("-a" "$asset")
-          done
-
           QLIK_VERSION=${GITHUB_REF/refs\/tags\//}
-          hub release create "${assets[@]}" -m "${QLIK_VERSION}" "${QLIK_VERSION}"
+
+          if gh release view "${QLIK_VERSION}"; then
+            gh release upload "${QLIK_VERSION}" ./bin/*.tar.gz --clobber
+          else
+            gh release create "${QLIK_VERSION}" -n "${QLIK_VERSION}" -p ./bin/*.tar.gz
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release can be created by either making one from GitHub Web UI https://github.com/qlik-oss/kustomize/releases or a tag push. Depending on which the release is either created (tag push) or just attach artifacts to an existing release (GitHub web release).