### PR TITLE
Add support for full clone

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: '1.14.15'
       id: go
 
     - name: Check out code into the Go module directory
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.13
+          go-version: '1.14.15'
         id: go
 
       - name: Check out code into the Go module directory
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.13
+          go-version: '1.14.15'
         id: go
 
       - name: Check out code into the Go module directory
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.13
+          go-version: '1.14.15'
         id: go
 
       - name: Check out code into the Go module directory

--- a/api/builtins_qlik/GoGetter.go
+++ b/api/builtins_qlik/GoGetter.go
@@ -290,19 +290,20 @@ func (p *GoGetterPlugin) clone(dst string, u *url.URL, ref string) error {
 		p.logger.Printf("error executing git config: %v\n", err)
 		return err
 	}
-
-	cmd = exec.Command("git", "sparse-checkout", "init", "--cone")
-	cmd.Dir = dst
-	if err := p.getRunCommand(cmd, nil); err != nil {
-		p.logger.Printf("error executing git sparse-checkout init: %v\n", err)
-		return err
-	}
-	// hard code for now
-	cmd = exec.Command("git", "sparse-checkout", "set", p.PartialCloneDir)
-	cmd.Dir = dst
-	if err := p.getRunCommand(cmd, nil); err != nil {
-		p.logger.Printf("error executing git space-checkout set: %v\n", err)
-		return err
+	if p.PartialCloneDir != "." {
+		cmd = exec.Command("git", "sparse-checkout", "init", "--cone")
+		cmd.Dir = dst
+		if err := p.getRunCommand(cmd, nil); err != nil {
+			p.logger.Printf("error executing git sparse-checkout init: %v\n", err)
+			return err
+		}
+		// hard code for now
+		cmd = exec.Command("git", "sparse-checkout", "set", p.PartialCloneDir)
+		cmd.Dir = dst
+		if err := p.getRunCommand(cmd, nil); err != nil {
+			p.logger.Printf("error executing git space-checkout set: %v\n", err)
+			return err
+		}
 	}
 	cmd = exec.Command("git", "checkout")
 	cmd.Dir = dst


### PR DESCRIPTION
`partialCloneDir= .` now does a full clone

go 1.16 causes dependency errors, pinned build to 1.14.15

Signed-off-by: Boris Kuschel <boris.kuschel@qlik.com>