### PR TITLE
Gomsert plugin, fix tests

### DIFF
--- a/api/builtins_qlik/GoGetter.go
+++ b/api/builtins_qlik/GoGetter.go
@@ -323,7 +323,9 @@ func (p *GoGetterPlugin) GoGit(u *url.URL, dir string) error {
 
 		u.RawQuery = q.Encode()
 	}
-
+	if len(ref) == 0 {
+		ref = p.findDefaultBranch(dir)
+	}
 	// Clone or update the repository
 	_, err := os.Stat(dir)
 	if err != nil && !os.IsNotExist(err) {
@@ -477,9 +479,7 @@ func (p *GoGetterPlugin) update(dst string, u *url.URL, ref string) error {
 	var stdoutbuf bytes.Buffer
 	var clone = true
 	var update = true
-	if len(ref) == 0 {
-		ref = p.findDefaultBranch(dst)
-	}
+
 	// Check if branch/tag/commit id changed (that order)
 	cmd := exec.Command("git", "symbolic-ref", "--short", "-q", "HEAD")
 	cmd.Dir = dst

--- a/api/builtins_qlik/Gomsert.go
+++ b/api/builtins_qlik/Gomsert.go
@@ -1,0 +1,149 @@
+package builtins_qlik
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"go.uber.org/zap"
+	"sigs.k8s.io/kustomize/api/builtins_qlik/utils"
+	"sigs.k8s.io/kustomize/api/filters/fieldspec"
+	"sigs.k8s.io/kustomize/api/ifc"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filtersutil"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
+	"sigs.k8s.io/yaml"
+)
+
+// inserts a processed gomplate file into a kustomize resource
+type GomsertPlugin struct {
+	LDelim      string   `json:"leftDelimeter" 	yaml:"leftDelimeter"`
+	RDelim      string   `json:"rightDelimeter" 	yaml:"rightDelimeter"`
+	DataSources []string `json:"dataSources,omitempty" 	yaml:"dataSources,omitempty"`
+	InputFile   string   `json:"inputFile,omitempty" 	yaml:"inputFile,omitempty"`
+	EnvVars     []struct {
+		Name          string `json:"name" 	yaml:"name"`
+		ValueFromEnv  string `json:"valueFromEnv,omitempty" 	yaml:"valueFromEnv,omitempty"`
+		ValueFromFile string `json:"valueFromFile,omitempty" 	yaml:"valueFromFile,omitempty"`
+		Value         string `json:"value,omitempty" 	yaml:"value,omitempty"`
+	} `json:"envVars,omitempty" 	yaml:"envVars,omitempty"`
+	Target      *types.Selector `json:"target,omitempty" yaml:"target,omitempty"`
+	Path        string          `json:"path,omitempty" yaml:"path,omitempty"`
+	Pwd         string
+	ldr         ifc.Loader
+	rf          *resmap.Factory
+	logger      *zap.SugaredLogger
+	fieldSpec   types.FieldSpec
+	replaceYaml []byte
+}
+
+func (p *GomsertPlugin) Config(h *resmap.PluginHelpers, c []byte) (err error) {
+	p.ldr = h.Loader()
+	p.rf = h.ResmapFactory()
+	p.Pwd = h.Loader().Root()
+	return yaml.Unmarshal(c, p)
+}
+
+func (p *GomsertPlugin) Transform(m resmap.ResMap) error {
+	if len(p.LDelim) <= 0 {
+		p.LDelim = "{{"
+	}
+	if len(p.RDelim) <= 0 {
+		p.RDelim = "}}"
+	}
+	p.fieldSpec = types.FieldSpec{Path: p.Path}
+	var data []byte
+	var err error
+
+	var env = make(map[string]string)
+
+	valuesFile := p.InputFile
+	if data, err = ioutil.ReadFile(valuesFile); err != nil {
+		return err
+	}
+
+	if p.DataSources != nil {
+
+		for _, envVar := range p.EnvVars {
+			if len(envVar.Value) > 0 {
+				env[envVar.Name] = envVar.Value
+			} else if len(envVar.ValueFromFile) > 0 {
+				if data, err = ioutil.ReadFile(envVar.ValueFromFile); err != nil {
+					return err
+				} else {
+					env[envVar.Name] = string(data)
+				}
+			} else if len(envVar.ValueFromEnv) > 0 {
+				if envValue, exists := os.LookupEnv(envVar.ValueFromEnv); err != nil || !exists {
+					if err != nil {
+						return err
+					}
+					return fmt.Errorf("environmental variable %v, does not exist", envVar.ValueFromEnv)
+				} else {
+					env[envVar.Name] = string(envValue)
+				}
+			} else {
+				if envValue, exists := os.LookupEnv(envVar.Name); err != nil || !exists {
+					if err != nil {
+						return err
+					}
+					return fmt.Errorf("environmental variable %v, does not exist", envVar.Name)
+				} else {
+					env[envVar.Name] = string(envValue)
+				}
+			}
+		}
+
+		if p.replaceYaml, err = utils.RunGomplateFromConfig(p.DataSources, p.Pwd, env, string(data), p.logger, p.LDelim, p.RDelim); err != nil {
+			p.logger.Errorf("error executing runGomplate() on dataSources: %v, in directory: %v, error: %v\n", p.DataSources, p.Pwd, err)
+		}
+		// Target
+		resources, err := m.Select(*p.Target)
+		if err != nil {
+			p.logger.Errorf("error selecting resources based on the target selector, error: %v\n", err)
+			return err
+		}
+		for _, r := range resources {
+			if err := filtersutil.ApplyToJSON(kio.FilterFunc(func(nodes []*kyaml.RNode) ([]*kyaml.RNode, error) {
+				return kio.FilterAll(kyaml.FilterFunc(func(rn *kyaml.RNode) (*kyaml.RNode, error) {
+					if err := rn.PipeE(fieldspec.Filter{
+						FieldSpec: p.fieldSpec,
+						SetValue: func(n *kyaml.RNode) error {
+							return p.searchAndReplaceRNode(n)
+						},
+					}); err != nil {
+						return nil, err
+					}
+					return rn, nil
+				})).Filter(nodes)
+			}), r); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("error, no data sources defined for gomplate")
+}
+
+func (p *GomsertPlugin) searchAndReplaceRNode(node *kyaml.RNode) error {
+	var in map[string]interface{}
+	if err := yaml.Unmarshal([]byte(p.replaceYaml), &in); err != nil {
+		p.logger.Infof("error unmarshalling JSON string after replacements back to interface, error: %v\n", err)
+		return err
+	}
+	if in != nil {
+		tempMap := map[string]interface{}{"tmp": in}
+		if tempMapRNode, err := utils.NewKyamlRNode(tempMap); err != nil {
+			return err
+		} else {
+			node.SetYNode(tempMapRNode.Field("tmp").Value.YNode())
+		}
+	}
+	return nil
+}
+
+func NewGomsertPlugin() resmap.TransformerPlugin {
+	return &GomsertPlugin{logger: utils.GetLogger("GomsertPlugin")}
+}

--- a/api/builtins_qlik/HelmChart_test.go
+++ b/api/builtins_qlik/HelmChart_test.go
@@ -858,7 +858,7 @@ repositories:
   keyFile: ""
   name: qlik
   password: ""
-  url: https://qliktech.jfrog.io/qliktech/qlikhelm
+  url: https://qlik-download.github.io/qseok
   username: ""
 `
 			return &helmRepoAddTestCaseT{
@@ -866,7 +866,7 @@ repositories:
 				repoFileContent: repoFileContent,
 				repoAddEntry: &repo.Entry{
 					Name: "qlik",
-					URL:  "https://qliktech.jfrog.io/qliktech/qlikhelm/",
+					URL:  "https://qlik-download.github.io/qseok/",
 				},
 				checkAssertions: func(t *testing.T, err error, resultRepoFileContent []byte) {
 					assert.NoError(t, err)
@@ -885,7 +885,7 @@ repositories:
   keyFile: ""
   name: qlik
   password: ""
-  url: https://qliktech.jfrog.io/qliktech/qlikhelm/
+  url: https://qlik-download.github.io/qseok/
   username: ""
 `
 			return &helmRepoAddTestCaseT{
@@ -893,7 +893,7 @@ repositories:
 				repoFileContent: repoFileContent,
 				repoAddEntry: &repo.Entry{
 					Name: "qlik",
-					URL:  "https://qliktech.jfrog.io/qliktech/qlikhelm",
+					URL:  "https://qlik-download.github.io/qseok",
 				},
 				checkAssertions: func(t *testing.T, err error, resultRepoFileContent []byte) {
 					assert.NoError(t, err)
@@ -912,7 +912,7 @@ repositories:
   keyFile: ""
   name: qlik
   password: ""
-  url: https://qliktech.jfrog.io/qliktech/qlikhelm
+  url: https://qlik-download.github.io/qseok
   username: ""
 `
 			return &helmRepoAddTestCaseT{
@@ -939,7 +939,7 @@ repositories:
   keyFile: ""
   name: qlik
   password: ""
-  url: https://qliktech.jfrog.io/qliktech/qlikhelm
+  url: https://qlik-download.github.io/qseok
   username: ""
 `
 			return &helmRepoAddTestCaseT{
@@ -947,7 +947,7 @@ repositories:
 				repoFileContent: repoFileContent,
 				repoAddEntry: &repo.Entry{
 					Name:     "qlik",
-					URL:      "https://qliktech.jfrog.io/qliktech/qlikhelm",
+					URL:      "https://qlik-download.github.io/qseok",
 					Username: "foobar",
 				},
 				checkAssertions: func(t *testing.T, err error, resultRepoFileContent []byte) {
@@ -961,7 +961,7 @@ repositories:
   keyFile: ""
   name: qlik
   password: ""
-  url: https://qliktech.jfrog.io/qliktech/qlikhelm
+  url: https://qlik-download.github.io/qseok
   username: foobar
 `, string(resultRepoFileContent))
 				},
@@ -978,7 +978,7 @@ repositories:
   keyFile: ""
   name: qlik
   password: ""
-  url: https://qliktech.jfrog.io/qliktech/qlikhelm
+  url: https://qlik-download.github.io/qseok
   username: ""
 `
 			return &helmRepoAddTestCaseT{
@@ -986,7 +986,7 @@ repositories:
 				repoFileContent: repoFileContent,
 				repoAddEntry: &repo.Entry{
 					Name:     "qlik",
-					URL:      "https://qliktech.jfrog.io/qliktech/qlikhelm",
+					URL:      "https://qlik-download.github.io/qseok",
 					Password: "foobar",
 				},
 				checkAssertions: func(t *testing.T, err error, resultRepoFileContent []byte) {
@@ -1000,7 +1000,7 @@ repositories:
   keyFile: ""
   name: qlik
   password: foobar
-  url: https://qliktech.jfrog.io/qliktech/qlikhelm
+  url: https://qlik-download.github.io/qseok
   username: ""
 `, string(resultRepoFileContent))
 				},

--- a/api/internal/plugins/builtinhelpers/builtins.go
+++ b/api/internal/plugins/builtinhelpers/builtins.go
@@ -44,6 +44,7 @@ const (
 	GitImageTag
 	GoGetter
 	Yaegi
+	Gomsert
 )
 
 var stringToBuiltinPluginTypeMap map[string]BuiltinPluginType
@@ -95,6 +96,9 @@ func init() {
 	TransformerFactories[Yaegi] = builtins_qlik.NewYaegiTransformerPlugin
 	GeneratorFactories[Yaegi] = builtins_qlik.NewYaegiGeneratorPlugin
 	stringToBuiltinPluginTypeMap["Yaegi"] = Yaegi
+
+	TransformerFactories[Gomsert] = builtins_qlik.NewGomsertPlugin
+	stringToBuiltinPluginTypeMap["Gomsert"] = Gomsert
 }
 
 func makeStringToBuiltinPluginTypeMap() (result map[string]BuiltinPluginType) {


### PR DESCRIPTION
New gomsert plugin.

**Description**
Gomsert plugin inserts the output template rendering into a kustomize resource at a given path.

`target:` the target object(s) into which the gomplate output will be placed
`path:` the path the the yaml attribute under which the document will be inserted (as a yaml node)
`inputFile:` The gomplate input file
`datasources:` The gomplate --datasources flag inputs
`envVars:` Allows environment variable to be defined for gomplate execution. Only specifying `name` forwards  the environment variable from the parent shell. Other options include:
- `value:` specify value of environmental variable
- `valueFromEnv:` specify a different env var to set the gomplate env var (redirect)
- `valueFromFile:` read value for env var from the contents of a file

_Example:_

```yaml
apiVersion: qlik.com/v1
kind: Gomsert
metadata:
  name: gomsert 
target:
  kind: HelmValues
path: values
inputFile: values.yaml
datasources:
  - "vault=./vault/?type=application/json"
envVars:
  - name: EJSON_KEY
  - name: ENVIRONMENT
    value: stage
  - name: REGION
    value: us-east-1
  - name: CONTAINER_REGISTRY_URL
    value: "ghcr.io/qlik-oss"
```